### PR TITLE
feat: add feather viewer extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
-# vscode-feather
+# Feather Viewer VS Code Extension
+
+View and explore `.feather` files directly inside VS Code using Python's [polars](https://www.pola.rs/) library.
+
+## Features
+- Pagination with next/previous and jump to page
+- Apply filters using polars expressions, e.g., `col("a") == 1`
+- Configurable Python interpreter path (`feather.pythonPath`), defaults to `python`
+
+## Requirements
+- Python with the `polars` package installed
+
+## Usage
+- Open a `.feather` file from the explorer (double-click) or right-click and choose **Open Feather File**.
+- You can also run the command **Feather: Open Feather File** from the Command Palette.
+- Use the webview controls to navigate pages or apply filters.

--- a/extension.js
+++ b/extension.js
@@ -1,0 +1,152 @@
+const vscode = require('vscode');
+const path = require('path');
+const child_process = require('child_process');
+
+class FeatherViewerProvider {
+  constructor(context) {
+    this.context = context;
+  }
+
+  openCustomDocument(uri) {
+    return { uri, dispose() {} };
+  }
+
+  async resolveCustomEditor(document, webviewPanel) {
+    webviewPanel.webview.options = { enableScripts: true };
+    webviewPanel.webview.html = getWebviewContent();
+
+    webviewPanel.webview.onDidReceiveMessage(async message => {
+      if (message.type === 'load') {
+        const result = await runPython(this.context, document.uri.fsPath, message.page, message.pageSize, message.filter);
+        if (result.error) {
+          webviewPanel.webview.postMessage({ type: 'error', error: result.error });
+        } else {
+          webviewPanel.webview.postMessage({
+            type: 'data',
+            columns: result.columns,
+            rows: result.rows,
+            totalRows: result.totalRows,
+            page: message.page,
+            pageSize: message.pageSize
+          });
+        }
+      }
+    });
+  }
+}
+
+function activate(context) {
+  const provider = new FeatherViewerProvider(context);
+  context.subscriptions.push(
+    vscode.window.registerCustomEditorProvider('feather.viewer', provider, { supportsMultipleEditorsPerDocument: false })
+  );
+
+  const openCommand = vscode.commands.registerCommand('feather.openFeather', async (uri) => {
+    if (!uri) {
+      const fileUris = await vscode.window.showOpenDialog({
+        canSelectMany: false,
+        filters: { 'Feather Files': ['feather'] }
+      });
+      if (!fileUris || fileUris.length === 0) {
+        return;
+      }
+      uri = fileUris[0];
+    }
+    await vscode.commands.executeCommand('vscode.openWith', uri, 'feather.viewer');
+  });
+
+  context.subscriptions.push(openCommand);
+}
+
+exports.activate = activate;
+
+function deactivate() {}
+exports.deactivate = deactivate;
+
+function runPython(context, file, page, pageSize, filter) {
+  return new Promise(resolve => {
+    const config = vscode.workspace.getConfiguration('feather');
+    const pythonPath = config.get('pythonPath', 'python');
+    const script = context.asAbsolutePath(path.join('python', 'viewer.py'));
+    const args = [script, file, '--page', String(page), '--page_size', String(pageSize)];
+    if (filter) {
+      args.push('--filter', filter);
+    }
+    const py = child_process.spawn(pythonPath, args);
+    let out = '';
+    let err = '';
+    py.stdout.on('data', d => out += d);
+    py.stderr.on('data', d => err += d);
+    py.on('close', () => {
+      try {
+        resolve(JSON.parse(out));
+      } catch (e) {
+        resolve({ error: err || e.message });
+      }
+    });
+  });
+}
+
+function getWebviewContent() {
+  return `<!DOCTYPE html>
+<html lang="en">
+<body>
+  <div>
+    <label>Page Size: <input id="pageSize" value="100" /></label>
+    <label>Page: <input id="pageNumber" value="1" /></label>
+    <button id="gotoBtn">Go</button>
+    <button id="prevBtn">Prev</button>
+    <button id="nextBtn">Next</button>
+    <input id="filterInput" placeholder='Filter (e.g., col("column") == 1)' />
+    <button id="filterBtn">Apply Filter</button>
+  </div>
+  <div id="status"></div>
+  <table id="data"></table>
+  <script>
+    const vscode = acquireVsCodeApi();
+    let currentPage = 0;
+    function request(page){
+      const pageSize = parseInt(document.getElementById('pageSize').value) || 100;
+      const filter = document.getElementById('filterInput').value;
+      vscode.postMessage({ type: 'load', page, pageSize, filter });
+    }
+    document.getElementById('nextBtn').addEventListener('click', () => request(currentPage + 1));
+    document.getElementById('prevBtn').addEventListener('click', () => request(Math.max(0, currentPage - 1)));
+    document.getElementById('gotoBtn').addEventListener('click', () => {
+      const p = parseInt(document.getElementById('pageNumber').value) - 1;
+      request(p);
+    });
+    document.getElementById('filterBtn').addEventListener('click', () => request(0));
+    window.addEventListener('message', event => {
+      const msg = event.data;
+      if (msg.type === 'data') {
+        currentPage = msg.page;
+        document.getElementById('pageNumber').value = msg.page + 1;
+        const table = document.getElementById('data');
+        table.innerHTML = '';
+        const header = document.createElement('tr');
+        for (const c of msg.columns) {
+          const th = document.createElement('th');
+          th.textContent = c;
+          header.appendChild(th);
+        }
+        table.appendChild(header);
+        for (const row of msg.rows) {
+          const tr = document.createElement('tr');
+          for (const c of msg.columns) {
+            const td = document.createElement('td');
+            td.textContent = row[c];
+            tr.appendChild(td);
+          }
+          table.appendChild(tr);
+        }
+        document.getElementById('status').textContent = 'Showing ' + (msg.page * msg.pageSize + 1) + '-' + (msg.page * msg.pageSize + msg.rows.length) + ' of ' + msg.totalRows;
+      } else if (msg.type === 'error') {
+        document.getElementById('status').textContent = msg.error;
+      }
+    });
+    request(0);
+  </script>
+</body>
+</html>`;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,59 @@
+{
+  "name": "vscode-feather-viewer",
+  "displayName": "Feather Viewer",
+  "description": "View Feather files using Python polars",
+  "version": "0.0.1",
+  "publisher": "feather",
+  "engines": {
+    "vscode": "^1.50.0"
+  },
+  "activationEvents": [
+    "onCommand:feather.openFeather",
+    "onCustomEditor:feather.viewer"
+  ],
+  "main": "./extension.js",
+  "contributes": {
+    "commands": [
+      {
+        "command": "feather.openFeather",
+        "title": "Open Feather File"
+      }
+    ],
+    "menus": {
+      "explorer/context": [
+        {
+          "command": "feather.openFeather",
+          "when": "resourceExtname == .feather",
+          "group": "navigation"
+        }
+      ]
+    },
+    "customEditors": [
+      {
+        "viewType": "feather.viewer",
+        "displayName": "Feather Viewer",
+        "selector": [
+          {
+            "filenamePattern": "*.feather"
+          }
+        ],
+        "priority": "default"
+      }
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Feather Viewer",
+      "properties": {
+        "feather.pythonPath": {
+          "type": "string",
+          "default": "python",
+          "description": "Path to the Python executable"
+        }
+      }
+    }
+  },
+  "scripts": {
+    "test": "echo 'No tests'"
+  },
+  "dependencies": {}
+}

--- a/python/viewer.py
+++ b/python/viewer.py
@@ -1,0 +1,46 @@
+import argparse
+import json
+
+try:
+    import polars as pl
+except Exception as e:
+    print(json.dumps({"error": f"Failed to import polars: {e}"}))
+    raise SystemExit(0)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Read feather file and output page as JSON")
+    parser.add_argument('file', help='Path to feather file')
+    parser.add_argument('--page', type=int, default=0, help='Page number (0-based)')
+    parser.add_argument('--page_size', type=int, default=100, help='Number of rows per page')
+    parser.add_argument('--filter', default='', help='Polars filter expression, e.g., col("a") == 1')
+    args = parser.parse_args()
+
+    try:
+        df = pl.read_ipc(args.file)
+    except Exception as e:
+        print(json.dumps({"error": f"Failed to read file: {e}"}))
+        return
+
+    if args.filter:
+        try:
+            expr = eval(args.filter, {"pl": pl, "col": pl.col})
+            df = df.filter(expr)
+        except Exception as e:
+            print(json.dumps({"error": f"Bad filter expression: {e}"}))
+            return
+
+    total_rows = df.height
+    start = args.page * args.page_size
+    df_page = df.slice(start, args.page_size)
+
+    result = {
+        "columns": df.columns,
+        "rows": df_page.to_dicts(),
+        "totalRows": total_rows
+    }
+    print(json.dumps(result))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add VS Code extension to view feather files using polars
- support configurable python path and basic pagination/filtering
- allow opening feather files directly from the explorer or by double-click
- fix activation error by removing unescaped template string in status message

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7ccdc7a1c832c8ff8b5ebcf754582